### PR TITLE
Fix glyph source contours for U+A29A and U+A3E0 in Noto Sans Yi

### DIFF
--- a/sources/NotoSansYi-Regular.ufo/glyphs/uniA_29A_.glif
+++ b/sources/NotoSansYi-Regular.ufo/glyphs/uniA_29A_.glif
@@ -3,59 +3,64 @@
 	<unicode hex="A29A"/>
 	<advance width="604"/>
 	<outline>
-		<contour>
-			<point x="206" y="-10" type="line"/>
-			<point x="206" y="268" type="line"/>
-			<point x="263" y="268" type="line"/>
-			<point x="269" y="158"/>
-			<point x="293" y="70"/>
-			<point x="398" y="70" type="curve" smooth="yes"/>
-			<point x="533" y="70"/>
-			<point x="536" y="221"/>
-			<point x="536" y="336" type="curve" smooth="yes"/>
-			<point x="536" y="394" type="line"/>
-			<point x="536" y="543"/>
-			<point x="532" y="673"/>
-			<point x="399" y="673" type="curve" smooth="yes"/>
-			<point x="290" y="673"/>
-			<point x="267" y="589"/>
-			<point x="262" y="478" type="curve"/>
-			<point x="206" y="478" type="line"/>
-			<point x="206" y="714" type="line"/>
-			<point x="137" y="714" type="line"/>
-			<point x="137" y="113" type="line"/>
-			<point x="67" y="162" type="line"/>
-			<point x="39" y="111" type="line"/>
-		</contour>
-		<contour>
-			<point x="398" y="129" type="curve" smooth="yes"/>
-			<point x="344" y="129"/>
-			<point x="332" y="180"/>
-			<point x="330" y="268" type="curve"/>
-			<point x="467" y="268" type="line"/>
-			<point x="465" y="179"/>
-			<point x="454" y="129"/>
-		</contour>
-		<contour>
-			<point x="206" y="327" type="line"/>
-			<point x="206" y="419" type="line"/>
-			<point x="261" y="419" type="line"/>
-			<point x="261" y="327" type="line"/>
-		</contour>
-		<contour>
-			<point x="330" y="327" type="line"/>
-			<point x="330" y="419" type="line"/>
-			<point x="468" y="419" type="line"/>
-			<point x="468" y="327" type="line"/>
-		</contour>
-		<contour>
-			<point x="330" y="478" type="line"/>
-			<point x="332" y="567"/>
-			<point x="343" y="614"/>
-			<point x="398" y="614" type="curve" smooth="yes"/>
-			<point x="453" y="614"/>
-			<point x="465" y="566"/>
-			<point x="467" y="478" type="curve"/>
-		</contour>
-	</outline>
+    <contour>
+      <point x="276" y="578" type="qcurve" smooth="yes"/>
+      <point x="290" y="625"/>
+      <point x="316" y="648" type="qcurve" smooth="yes"/>
+      <point x="345" y="673"/>
+      <point x="399" y="673" type="qcurve" smooth="yes"/>
+      <point x="449" y="673"/>
+      <point x="505" y="628"/>
+      <point x="530" y="550"/>
+      <point x="536" y="450"/>
+      <point x="536" y="394" type="qcurve" smooth="yes"/>
+      <point x="536" y="336"/>
+      <point x="536" y="336" type="qcurve" smooth="yes"/>
+      <point x="536" y="293"/>
+      <point x="530" y="200"/>
+      <point x="505" y="120"/>
+      <point x="449" y="70"/>
+      <point x="398" y="70" type="qcurve" smooth="yes"/>
+      <point x="346" y="70"/>
+      <point x="289" y="123"/>
+      <point x="266" y="213"/>
+      <point x="263" y="268" type="qcurve"/>
+      <point x="263" y="268"/>
+      <point x="206" y="268" type="qcurve"/>
+      <point x="206" y="-10" type="line"/>
+      <point x="39" y="111" type="line"/>
+      <point x="67" y="162" type="line"/>
+      <point x="137" y="113" type="line"/>
+      <point x="137" y="714" type="line"/>
+      <point x="206" y="714" type="line"/>
+      <point x="206" y="327" type="line"/>
+      <point x="261" y="327" type="line"/>
+      <point x="262" y="460" type="line" smooth="yes"/>
+      <point x="263" y="532"/>
+    </contour>
+    <contour>
+      <point x="330" y="478" type="qcurve"/>
+      <point x="467" y="478" type="line"/>
+      <point x="466" y="544"/>
+      <point x="439" y="614"/>
+      <point x="398" y="614" type="qcurve" smooth="yes"/>
+      <point x="357" y="614"/>
+      <point x="332" y="545"/>
+    </contour>
+    <contour>
+      <point x="330" y="327" type="line"/>
+      <point x="468" y="327" type="line"/>
+      <point x="468" y="419" type="line"/>
+      <point x="330" y="419" type="line"/>
+    </contour>
+    <contour>
+      <point x="398" y="129" type="qcurve" smooth="yes"/>
+      <point x="440" y="129"/>
+      <point x="466" y="201"/>
+      <point x="467" y="268" type="qcurve"/>
+      <point x="330" y="268" type="line"/>
+      <point x="332" y="202"/>
+      <point x="358" y="129"/>
+    </contour>
+  </outline>
 </glyph>

--- a/sources/NotoSansYi-Regular.ufo/glyphs/uniA_3E_0.glif
+++ b/sources/NotoSansYi-Regular.ufo/glyphs/uniA_3E_0.glif
@@ -3,39 +3,57 @@
 	<unicode hex="A3E0"/>
 	<advance width="561"/>
 	<outline>
-		<contour>
-			<point x="248" y="192" type="line"/>
-			<point x="311" y="192" type="line"/>
-			<point x="311" y="404" type="line"/>
-			<point x="489" y="287" type="line"/>
-			<point x="489" y="616" type="line"/>
-			<point x="421" y="616" type="line"/>
-			<point x="421" y="398" type="line"/>
-			<point x="311" y="471" type="line"/>
-			<point x="311" y="714" type="line"/>
-			<point x="248" y="714" type="line"/>
-			<point x="248" y="513" type="line"/>
-			<point x="69" y="631" type="line"/>
-			<point x="69" y="307" type="line"/>
-			<point x="138" y="307" type="line"/>
-			<point x="138" y="518" type="line"/>
-			<point x="248" y="446" type="line"/>
-		</contour>
-		<contour>
-			<point x="282" y="-13" type="curve" smooth="yes"/>
-			<point x="401" y="-13"/>
-			<point x="478" y="61"/>
-			<point x="507" y="193" type="curve"/>
-			<point x="442" y="217" type="line"/>
-			<point x="424" y="110"/>
-			<point x="374" y="46"/>
-			<point x="282" y="46" type="curve" smooth="yes"/>
-			<point x="184" y="46"/>
-			<point x="135" y="113"/>
-			<point x="119" y="217" type="curve"/>
-			<point x="54" y="193" type="line"/>
-			<point x="77" y="84"/>
-			<point x="142" y="-13"/>
-		</contour>
-	</outline>
+    <contour>
+      <point x="279" y="908" type="qcurve" smooth="yes"/>
+      <point x="349" y="908"/>
+      <point x="442" y="850"/>
+      <point x="495" y="756"/>
+      <point x="507" y="702" type="qcurve"/>
+      <point x="442" y="678" type="line"/>
+      <point x="430" y="756"/>
+      <point x="352" y="849"/>
+      <point x="279" y="849" type="qcurve" smooth="yes"/>
+      <point x="210" y="849"/>
+      <point x="132" y="758"/>
+      <point x="119" y="678" type="qcurve"/>
+      <point x="54" y="702" type="line"/>
+      <point x="76" y="801"/>
+      <point x="190" y="908"/>
+    </contour>
+    <contour>
+      <point x="248" y="192" type="line"/>
+      <point x="248" y="446" type="line"/>
+      <point x="138" y="518" type="line"/>
+      <point x="138" y="307" type="line"/>
+      <point x="69" y="307" type="line"/>
+      <point x="69" y="631" type="line"/>
+      <point x="248" y="513" type="line"/>
+      <point x="248" y="714" type="line"/>
+      <point x="311" y="714" type="line"/>
+      <point x="311" y="471" type="line"/>
+      <point x="421" y="398" type="line"/>
+      <point x="421" y="616" type="line"/>
+      <point x="489" y="616" type="line"/>
+      <point x="489" y="287" type="line"/>
+      <point x="311" y="404" type="line"/>
+      <point x="311" y="192" type="line"/>
+    </contour>
+    <contour>
+      <point x="282" y="-13" type="qcurve" smooth="yes"/>
+      <point x="212" y="-13"/>
+      <point x="119" y="45"/>
+      <point x="66" y="139"/>
+      <point x="54" y="193" type="qcurve"/>
+      <point x="119" y="217" type="line"/>
+      <point x="131" y="139"/>
+      <point x="209" y="46"/>
+      <point x="282" y="46" type="qcurve" smooth="yes"/>
+      <point x="351" y="46"/>
+      <point x="429" y="137"/>
+      <point x="442" y="217" type="qcurve"/>
+      <point x="507" y="193" type="line"/>
+      <point x="485" y="94"/>
+      <point x="371" y="-13"/>
+    </contour>
+  </outline>
 </glyph>


### PR DESCRIPTION
### Description
This Pull Request directly fixes the stroke errors and structural omissions for two standardized Liangshan Yi characters: **U+A29A** and **U+A3E0**. 

Instead of modifying the compiled binary, I have updated the corresponding `.glif` source files directly in the `sources/` directory with the corrected Bézier paths. 

### Changes Made
* **`uniA_29A_.glif`**: Corrected the stroke structure and fixed the contour paths to align with standard Yi script orthography.
* **`uniA_3E_0.glif`**: Completed the missing upper arc/stroke structure based on accepted linguistic standards.
* All modified glyph paths have been validated to ensure proper contour direction (clockwise for outer boundaries) and have undergone overlap removal to prevent rendering artifacts.

### References
* The corrections are based on universally accepted representations found in standard Yi script references and alternative open-source implementations like **Nuosu SIL**.
* Detailed discussion, background information, and visual comparisons from FontForge environment tests can be found in the linked issue.

Fixes #4 